### PR TITLE
Compile a native sdb binary when cross building

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -118,6 +118,17 @@ sdb_exe = executable('sdb', 'src/main.c',
   implicit_include_directories: false
 )
 
+if meson.is_cross_build()
+  sdb_native_exe = executable('sdb_native', 'src/main.c',
+    include_directories: sdb_inc,
+    link_with: [link_with],
+    install: false,
+    implicit_include_directories: false
+  )
+else
+  sdb_native_exe = sdb_exe
+endif
+
 if not meson.is_subproject()
   install_man(['src/sdb.1'])
 endif


### PR DESCRIPTION
sdb binary may be used by the build machine to compile .sdb files. In
that case it is necessary to have the sdb binary compiled for the build
machine and not for the host one, as it is by default.