### PR TITLE
Use library instead of both_libraries and mesonify tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -71,7 +71,7 @@ if get_option('local') and get_option('default_library') == 'shared'
   rpath_exe = '$ORIGIN/../' + get_option('libdir')
 endif
 
-libsdb = both_libraries('sdb', libsdb_sources,
+libsdb = library('sdb', libsdb_sources,
   include_directories: sdb_inc,
   implicit_include_directories: false,
   soversion: sdb_libversion,
@@ -80,7 +80,7 @@ libsdb = both_libraries('sdb', libsdb_sources,
 )
 
 sdb_dep = declare_dependency(
-  link_with: libsdb.get_static_lib(),
+  link_with: libsdb,
   include_directories: sdb_inc
 )
 
@@ -104,15 +104,9 @@ if not meson.is_subproject()
   install_headers(include_files, subdir: 'sdb')
 endif
 
-if host_machine.system() == 'windows'
-  link_with = libsdb.get_static_lib()
-else
-  link_with = libsdb.get_shared_lib()
-endif
-
 sdb_exe = executable('sdb', 'src/main.c',
   include_directories: sdb_inc,
-  link_with: [link_with],
+  link_with: libsdb,
   install: not meson.is_subproject(),
   install_rpath: rpath_exe,
   implicit_include_directories: false
@@ -136,7 +130,7 @@ endif
 pkgconfig_mod.generate(
   name: 'sdb',
   filebase: 'sdb',
-  libraries: [libsdb.get_shared_lib()],
+  libraries: libsdb,
   description: 'Simple DataBase',
   subdirs: ['sdb'],
   version: sdb_version,
@@ -144,16 +138,5 @@ pkgconfig_mod.generate(
 )
 
 if not meson.is_subproject()
-  make_exe = find_program('make', required: false)
-  if make_exe.found()
-    test('run tests', make_exe,
-      args: 'test',
-      env: ['BASEDIR=' + meson.current_build_dir()],
-      workdir: join_paths(meson.current_build_dir(), '..'),
-      depends: [sdb_exe, libsdb]
-    )
-  endif
-
-  subdir('test/bench')
-  subdir('test/unit')
+  subdir('test')
 endif

--- a/test/bench/meson.build
+++ b/test/bench/meson.build
@@ -10,8 +10,7 @@ tests = [
 foreach test : tests
   name = 'bench-' + test
   exe = executable(name, name + '.c',
-    include_directories: sdb_inc,
-    link_with: libsdb.get_static_lib()
+    dependencies: sdb_dep,
   )
   benchmark(name, exe)
 endforeach

--- a/test/merge.c
+++ b/test/merge.c
@@ -2,7 +2,6 @@
 #include <sdb.h>
 
 int main() {
-	const char *v;
 	Sdb *s = sdb_new0 ();
 	Sdb *d = sdb_new0 ();
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,32 @@
+if get_option('enable_tests')
+  tests = [
+    'siolpain',
+    'fmt',
+    'stack',
+    'cas',
+    'hook',
+    'hook2',
+    'stress1',
+    'fmtarr',
+    'bench-expire',
+    'expire',
+    'dumptwice',
+    'syncget',
+    'nsabuse',
+    'drain',
+    'merge',
+    # 'chkkey', the test is empty anyway
+  ]
+
+  foreach test : tests
+    exe = executable('test_@0@'.format(test), '@0@.c'.format(test),
+      dependencies: [sdb_dep],
+      install: false,
+      implicit_include_directories: false
+    )
+    test(test, exe, workdir: join_paths(meson.current_source_dir()))
+  endforeach
+
+  subdir('bench')
+  subdir('unit')
+endif

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -1,4 +1,3 @@
-
 if get_option('enable_tests')
   tests = [
     'array',


### PR DESCRIPTION
Few things here:
* just use `library` so dynamic library won't be compiled when compiled from rizin, where we just care about static lib
* hopefully fix the issue on MacOS (https://github.com/rizinorg/rizin/pull/191/checks?check_run_id=1560405676#step:12:176) because the dynamic lib is not compiled anymore
* hopefully fix windows issue (https://ci.appveyor.com/project/rizinorg/rizin/builds/36856084/job/ppl5mgrhb33y7fqx) but this needs to be checked... In any case, I think the changes are good without even considering this point
* mesonify tests a bit more