### PR TITLE
Rename ULLFMT to LLFMT

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -307,7 +307,7 @@ SDB_API const char *sdb_json_format(SdbJsonString *s, const char *fmt, ...) {
 			case 'l':
 				JSONSTR_ALLOCATE (32);
 				arg_l = va_arg (ap, ut64);
-				snprintf (tmp, sizeof (tmp), "0x%"ULLFMT "x", arg_l);
+				snprintf (tmp, sizeof (tmp), "0x%"LLFMT"x", arg_l);
 				memcpy (s->buf + s->len, tmp, strlen (tmp));
 				s->len += strlen (tmp);
 				break;

--- a/src/main.c
+++ b/src/main.c
@@ -191,7 +191,7 @@ static int sdb_grep_dump(const char *dbname, int fmt, bool grep,
 			if (!strcmp (v, "true") || !strcmp (v, "false")) {
 				printf ("%s\"%s\":%s", comma, k, v);
 			} else if (sdb_isnum (v)) {
-				printf ("%s\"%s\":%"ULLFMT"u", comma, k, sdb_atoi (v));
+				printf ("%s\"%s\":%"LLFMT"u", comma, k, sdb_atoi (v));
 			} else if (*v == '{' || *v == '[') {
 				printf ("%s\"%s\":%s", comma, k, v);
 			} else {

--- a/src/query.c
+++ b/src/query.c
@@ -468,7 +468,7 @@ next_quote:
 			}
 			// keep base
 			if (base == 16) {
-				w = snprintf (buf, len - 1, "0x%"ULLFMT"x", n);
+				w = snprintf (buf, len - 1, "0x%"LLFMT"x", n);
 				if (w < 0 || (size_t)w > len) {
 					if (bufset && len < 0xff) {
 						free (buf);
@@ -478,10 +478,10 @@ next_quote:
 						}
 					}
 					bufset = 1;
-					snprintf (buf, 0xff, "0x%"ULLFMT"x", n);
+					snprintf (buf, 0xff, "0x%"LLFMT"x", n);
 				}
 			} else {
-				w = snprintf (buf, len-1, "%"ULLFMT"d", n);
+				w = snprintf (buf, len-1, "%"LLFMT"d", n);
 				if (w < 0 || (size_t)w > len) {
 					if (bufset && len < 0xff) {
 						free (buf);
@@ -491,7 +491,7 @@ next_quote:
 						}
 					}
 					bufset = 1;
-					snprintf (buf, 0xff, "%"ULLFMT"d", n);
+					snprintf (buf, 0xff, "%"LLFMT"d", n);
 				}
 			}
 		}

--- a/src/types.h
+++ b/src/types.h
@@ -50,10 +50,10 @@
 #include <inttypes.h>
 #if __SDB_WINDOWS__ && !__CYGWIN__
 #define HAVE_MMAN 0
-#define ULLFMT "I64"
+#define LLFMT "I64"
 #else
 #define HAVE_MMAN 1
-#define ULLFMT "ll"
+#define LLFMT "ll"
 #endif
 
 #ifndef USE_MMAN

--- a/test/fmt.c
+++ b/test/fmt.c
@@ -15,7 +15,7 @@ int main() {
 	sdb_fmt_init (&p, "dsqd");
 	sdb_fmt_tobin ("123,bar,321,1", "dsqd", &p);
 	eprintf ("--> %d,%s\n", p.foo, p.str);
-	eprintf ("--> %"ULLFMT"d,%d\n", p.fin, p.end);
+	eprintf ("--> %"LLFMT"d,%d\n", p.fin, p.end);
 
 	{
 		char *o = sdb_fmt_tostr (&p, "dsqd");

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -94,7 +94,7 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 		ut64 exp__ = (ut64)(expected); \
 		if ((exp__) != (act__)) { \
 			char _meqstr[2048]; \
-			sprintf(_meqstr, "%s: expected %"ULLFMT"d, got %"ULLFMT"d.", (message), (long long)(exp__), (ut64)(act__)); \
+			sprintf(_meqstr, "%s: expected %"LLFMT"d, got %"LLFMT"d.", (message), (long long)(exp__), (ut64)(act__)); \
 			mu_assert(_meqstr, false); \
 		} \
 	} while(0)
@@ -103,7 +103,7 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 		char _meqstr[2048]; \
 		ut64 act__ = (ut64)(actual); \
 		ut64 exp__ = (ut64)(expected); \
-		sprintf(_meqstr, "%s: expected not %"ULLFMT"d, got %"ULLFMT"d.", (message), (long long)(exp__), (act__)); \
+		sprintf(_meqstr, "%s: expected not %"LLFMT"d, got %"LLFMT"d.", (message), (long long)(exp__), (act__)); \
 		mu_assert(_meqstr, (exp__) != (act__)); \
 	} while(0)
 


### PR DESCRIPTION
This pr renames `ULLFMT` to `LLFMT` since it's for `long long`, not just `unsigned long long`.