### PR TITLE
Set default buildtype to debugoptimized and fix warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('sdb', 'c', meson_version: '>=0.49.0', default_options: [
-  'b_vscrt=from_buildtype'
+  'buildtype=debugoptimized', 'b_vscrt=from_buildtype'
 ])
 py3_exe = import('python').find_installation('python3')
 pkgconfig_mod = import('pkgconfig')

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@ static void terminate(int sig UNUSED) {
 }
 
 static void write_null(void) {
-	(void)write (1, "", 1);
+	write_ (1, "", 1);
 }
 
 #define BS 128
@@ -353,7 +353,7 @@ static int base64decode(void) {
 		int declen;
 		out = sdb_decode (in, &declen);
 		if (out && declen >= 0) {
-			(void)write (1, out, declen);
+			write_ (1, out, declen);
 			ret = 0;
 		}
 		free (out);

--- a/src/sdb.c
+++ b/src/sdb.c
@@ -867,8 +867,7 @@ SDB_API SdbKv *sdb_dump_next(Sdb* s) {
 		return NULL;
 	}
 	vl--;
-	strncpy (sdbkv_key (&s->tmpkv), k, SDB_KSZ - 1);
-	sdbkv_key (&s->tmpkv)[SDB_KSZ - 1] = '\0';
+	strncpy (sdbkv_key (&s->tmpkv), k, SDB_KSZ);
 	free (sdbkv_value (&s->tmpkv));
 	s->tmpkv.base.value = v;
 	s->tmpkv.base.value_len = vl;

--- a/src/sdb.h
+++ b/src/sdb.h
@@ -78,8 +78,8 @@ extern char *strdup (const char *);
 #define SDB_LIST_SORTED 1
 
 // This size implies trailing zero terminator, this is 254 chars + 0
-#define SDB_KSZ 0xff
-#define SDB_VSZ 0xffffff
+#define SDB_KSZ SDB_MAX_KEY
+#define SDB_VSZ SDB_MAX_VALUE
 
 
 typedef struct sdb_t {

--- a/src/text.c
+++ b/src/text.c
@@ -2,7 +2,6 @@
 
 #include "sdb.h"
 
-#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <sys/stat.h>
@@ -65,10 +64,6 @@ static int cmp_ns(const void *a, const void *b) {
 	const SdbNs *cia = b;
 	return strcmp (nsa->name, cia->name);
 }
-
-#define write_(fd, buf, count) \
-	if (write ((fd), (buf), (count)) == -1) \
-		eprintf ("write_ ("#fd", "#buf", "#count") at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
 
 // n = position we are currently looking at
 // p = position until we have already written everything

--- a/src/text.c
+++ b/src/text.c
@@ -2,6 +2,7 @@
 
 #include "sdb.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <sys/stat.h>
@@ -65,11 +66,9 @@ static int cmp_ns(const void *a, const void *b) {
 	return strcmp (nsa->name, cia->name);
 }
 
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
 #define write_(fd, buf, count) \
 	if (write ((fd), (buf), (count)) == -1) \
-		perror ("write_ ("#fd", "#buf", "#count") at "__FILE__":"TOSTRING(__LINE__)" failed")
+		eprintf ("write_ ("#fd", "#buf", "#count") at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
 
 // n = position we are currently looking at
 // p = position until we have already written everything
@@ -184,8 +183,6 @@ static bool text_save(Sdb *s, int fd, bool sort, SdbList *path) {
 
 	return true;
 }
-#undef STRINGIFY
-#undef TOSTRING
 #undef write_
 
 SDB_API bool sdb_text_save_fd(Sdb *s, int fd, bool sort) {

--- a/src/types.h
+++ b/src/types.h
@@ -103,13 +103,11 @@
 
 #include "config.h"
 
-#define write_(fd, buf, count) \
-	if (write ((fd), (buf), (count)) == -1) \
-		eprintf ("write_ ("#fd", "#buf", "#count") at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
-
-#define read_(fd, buf, count) \
-	if (read ((fd), (buf), (count)) == -1) \
-		eprintf ("read_ ("#fd", "#buf", "#count") at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
+#define SDB_V_NOT(op, fail_ret) \
+	if ((op) == (fail_ret)) \
+		eprintf (#op" at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
+#define write_(fd, buf, count) SDB_V_NOT (write (fd, buf, count), -1)
+#define read_(fd, buf, count) SDB_V_NOT (read (fd, buf, count), -1)
 
 static inline int seek_set(int fd, off_t pos) {
 	return ((fd == -1) || (lseek (fd, (off_t) pos, SEEK_SET) == -1))? 0:1;

--- a/src/types.h
+++ b/src/types.h
@@ -1,6 +1,7 @@
 #ifndef TYPES_H
 #define TYPES_H
 
+#include <errno.h>
 #include <sys/types.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -101,6 +102,10 @@
 #endif
 
 #include "config.h"
+
+#define write_(fd, buf, count) \
+	if (write ((fd), (buf), (count)) == -1) \
+		eprintf ("write_ ("#fd", "#buf", "#count") at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
 
 static inline int seek_set(int fd, off_t pos) {
 	return ((fd == -1) || (lseek (fd, (off_t) pos, SEEK_SET) == -1))? 0:1;

--- a/src/types.h
+++ b/src/types.h
@@ -107,6 +107,10 @@
 	if (write ((fd), (buf), (count)) == -1) \
 		eprintf ("write_ ("#fd", "#buf", "#count") at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
 
+#define read_(fd, buf, count) \
+	if (read ((fd), (buf), (count)) == -1) \
+		eprintf ("read_ ("#fd", "#buf", "#count") at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
+
 static inline int seek_set(int fd, off_t pos) {
 	return ((fd == -1) || (lseek (fd, (off_t) pos, SEEK_SET) == -1))? 0:1;
 }

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -73,7 +73,7 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 #define mu_assert_true(actual, message) do { \
 		bool act__ = (actual); \
 		if (!(act__)) { \
-			char _meqstr[2048]; \
+			char _meqstr[5120]; \
 			sprintf (_meqstr, "%s: expected true, got false", (message)); \
 			mu_assert (_meqstr, false); \
 		} \
@@ -83,7 +83,7 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 	do { \
 		bool act__ = (actual); \
 		if ((act__)) { \
-			char _meqstr[2048]; \
+			char _meqstr[5120]; \
 			sprintf (_meqstr, "%s: expected false, got true", (message)); \
 			mu_assert (_meqstr, false); \
 		} \
@@ -93,14 +93,14 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 		ut64 act__ = (ut64)(actual); \
 		ut64 exp__ = (ut64)(expected); \
 		if ((exp__) != (act__)) { \
-			char _meqstr[2048]; \
+			char _meqstr[5120]; \
 			sprintf(_meqstr, "%s: expected %"LLFMT"d, got %"LLFMT"d.", (message), (long long)(exp__), (ut64)(act__)); \
 			mu_assert(_meqstr, false); \
 		} \
 	} while(0)
 
 #define mu_assert_neq(actual, expected, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		ut64 act__ = (ut64)(actual); \
 		ut64 exp__ = (ut64)(expected); \
 		sprintf(_meqstr, "%s: expected not %"LLFMT"d, got %"LLFMT"d.", (message), (long long)(exp__), (act__)); \
@@ -108,7 +108,7 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 	} while(0)
 
 #define mu_assert_ptreq(actual, expected, message) do {	\
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const void *act__ = (actual); \
 		const void *exp__ = (expected); \
 		sprintf (_meqstr, "%s: expected %p, got %p.", (message), (exp__), (act__)); \
@@ -116,7 +116,7 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 	} while (0)
 
 #define mu_assert_ptrneq(actual, expected, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const void *act__ = (actual); \
 		const void *exp__ = (expected); \
 		sprintf (_meqstr, "%s: expected not %p, got %p.", (message), (exp__), (act__)); \
@@ -124,14 +124,14 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 	} while (0)
 
 #define mu_assert_null(actual, message) do {			\
-		char _meqstr[2048];					\
+		char _meqstr[5120];					\
 		const void *act__ = (actual); \
 		sprintf(_meqstr, "%s: expected to be NULL but it wasn't.", (message)); \
 		mu_assert(_meqstr, (act__) == NULL);		\
 	} while(0)
 
 #define mu_assert_notnull(actual, message) do {				\
-		char _meqstr[2048];					\
+		char _meqstr[5120];					\
 		const void *act__ = (actual); \
 		sprintf(_meqstr, "%s: expected to not be NULL but it was.", (message)); \
 		mu_assert(_meqstr, (act__) != NULL);			\
@@ -141,14 +141,14 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 		ut64 act__ = (ut64)(actual); \
 		ut64 exp__ = (ut64)(expected); \
 		if ((exp__) != (act__)) { \
-			char _meqstr[2048]; \
+			char _meqstr[5120]; \
 			sprintf(_meqstr, "%s: expected "fmt", got "fmt".", (message), (exp__), (act__)); \
 			mu_assert(_meqstr, false); \
 		} \
 	} while(0)
 
 #define mu_assert_streq(actual, expected, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const char *act__ = (actual); \
 		const char *exp__ = (expected); \
 		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (exp__), (act__)); \
@@ -162,7 +162,7 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 } while (0)
 
 #define mu_assert_nullable_streq(actual, expected, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const char *act__ = (actual); \
 		const char *exp__ = (expected); \
 		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (exp__ ? exp__ : "NULL"), (act__ ? act__ : "NULL")); \
@@ -170,7 +170,7 @@ void sprint_mem(char *out, const char *buf, size_t len) {
 } while(0)
 
 #define mu_assert_memeq(actual, expected, len, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const char *act__ = (actual); \
 		const char *exp__ = (expected); \
 		sprintf(_meqstr, "%s: expected ", message); \

--- a/test/unit/test_sdb.c
+++ b/test/unit/test_sdb.c
@@ -359,7 +359,7 @@ bool test_sdb_text_save_simple() {
 	bool succ = sdb_text_save_fd (db, fd, true);
 	lseek (fd, 0, SEEK_SET);
 	char buf[TEST_BUF_SZ] = { 0 };
-	read (fd, buf, sizeof (buf) - 1);
+	read_ (fd, buf, sizeof (buf) - 1);
 	close (fd);
 	unlink (".text_save_simple");
 
@@ -378,7 +378,7 @@ bool test_sdb_text_save_simple_unsorted() {
 	bool succ = sdb_text_save_fd (db, fd, false);
 	lseek (fd, 0, SEEK_SET);
 	char buf[TEST_BUF_SZ] = { 0 };
-	read (fd, buf, sizeof (buf) - 1);
+	read_ (fd, buf, sizeof (buf) - 1);
 	close (fd);
 	unlink (".text_save_simple_unsorted");
 
@@ -397,7 +397,7 @@ bool test_sdb_text_save() {
 	bool succ = sdb_text_save_fd (db, fd, true);
 	lseek (fd, 0, SEEK_SET);
 	char buf[TEST_BUF_SZ] = { 0 };
-	read (fd, buf, sizeof (buf) - 1);
+	read_ (fd, buf, sizeof (buf) - 1);
 	close (fd);
 	unlink (".text_save");
 


### PR DESCRIPTION
This pr sets default `buildtype` to `debugoptimized` for same reasons as https://github.com/rizinorg/rizin/issues/256 i.e. the compiler can catch more problems with optimization enabled and the generated code is theoretically faster.