### PR TITLE
Do not export symbols when compiling statically on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,11 @@ if get_option('default_library') == 'shared'
   endif
 endif
 
+if host_machine.system() == 'windows' and get_option('default_library') == 'static'
+  add_project_arguments('-DSDB_API=', language: 'c')
+  add_project_arguments('-DSDB_IPI=', language: 'c')
+endif
+
 subdir('src')
 
 sdb_exe = executable('sdb', 'src/main.c',


### PR DESCRIPTION
Without this, when compiling two libraries that both use SDB, there
would be name clashes because of the exported symbols. This is also
fixed in similar ways in LZ4 library, see:

https://github.com/lz4/lz4/blob/b6623e710d6bea36634d82547b0d89021b0d6549/contrib/meson/meson/lib/meson.build#L30

This allows to successfully compile https://github.com/rizinorg/rizin/pull/191 on Windows (see appveyor failure).