### PR TITLE
sdb_native_exec should be compiled with native: true

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,6 +80,7 @@ if meson.is_cross_build()
   sdb_native_exe = executable('sdb_native', 'src/main.c',
     dependencies: sdb_dep,
     install: false,
+    native: true,
     implicit_include_directories: false,
   )
 else


### PR DESCRIPTION
Probably a leftover when this was introduced