### PR TITLE
Check for available getpid() instead of using system defines

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,12 +36,26 @@ if get_option('local') and get_option('default_library') == 'shared'
   rpath_exe = '$ORIGIN/../' + get_option('libdir')
 endif
 
+userconf = configuration_data()
+userconf.set10('HAVE__GETPID', false)
+have_getpid = cc.has_function('getpid', prefix: '#include <unistd.h>')
+userconf.set10('HAVE_GETPID', have_getpid)
+if not have_getpid
+  userconf.set10('HAVE__GETPID', cc.has_function('_getpid', prefix: '#include <process.h>'))
+endif
+sdb_userconf_h = configure_file(
+  input : 'src/sdb_userconf.h.in',
+  output : 'sdb_userconf.h',
+  configuration : userconf,
+  install_dir : join_paths(sdb_incdir, 'sdb'),
+)
+
 # Create sdb_version.h
-conf_data = configuration_data()
-conf_data.set_quoted('SDB_VERSION', sdb_version, description : 'From config.mk')
+versionconf = configuration_data()
+versionconf.set_quoted('SDB_VERSION', sdb_version, description : 'From config.mk')
 sdb_version_h = configure_file(
   output : 'sdb_version.h',
-  configuration : conf_data,
+  configuration : versionconf,
   install_dir : join_paths(sdb_incdir, 'sdb'),
 )
 

--- a/meson.build
+++ b/meson.build
@@ -37,12 +37,8 @@ if get_option('local') and get_option('default_library') == 'shared'
 endif
 
 userconf = configuration_data()
-userconf.set10('HAVE__GETPID', false)
-have_getpid = cc.has_function('getpid', prefix: '#include <unistd.h>')
-userconf.set10('HAVE_GETPID', have_getpid)
-if not have_getpid
-  userconf.set10('HAVE__GETPID', cc.has_function('_getpid', prefix: '#include <process.h>'))
-endif
+userconf.set10('HAVE_GETPID', cc.has_function('getpid', prefix: '#include <unistd.h>'))
+userconf.set10('HAVE__GETPID', cc.has_function('_getpid', prefix: '#include <process.h>'))
 sdb_userconf_h = configure_file(
   input : 'src/sdb_userconf.h.in',
   output : 'sdb_userconf.h',

--- a/src/lock.c
+++ b/src/lock.c
@@ -22,6 +22,7 @@ SDB_API const char *sdb_lock_file(const char *f) {
 }
 
 #if HAVE_GETPID
+#include <unistd.h>
 #define os_getpid() getpid()
 #elif HAVE__GETPID
 #include <process.h>

--- a/src/lock.c
+++ b/src/lock.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include "sdb.h"
+#include "sdb_userconf.h"
 
 SDB_API const char *sdb_lock_file(const char *f) {
 	static char buf[128];
@@ -20,11 +21,13 @@ SDB_API const char *sdb_lock_file(const char *f) {
 	return buf;
 }
 
-#if __SDB_WINDOWS__ && !__CYGWIN__
+#if HAVE_GETPID
+#define os_getpid() getpid()
+#elif HAVE__GETPID
 #include <process.h>
 #define os_getpid() _getpid()
 #else
-#define os_getpid() getpid()
+#error No supported getpid() found
 #endif
 
 SDB_API bool sdb_lock(const char *s) {

--- a/src/sdb_userconf.h.in
+++ b/src/sdb_userconf.h.in
@@ -1,0 +1,7 @@
+#ifndef SDB_USERCONF_H
+#define SDB_USERCONF_H
+
+#define HAVE_GETPID  @HAVE_GETPID@
+#define HAVE__GETPID @HAVE__GETPID@
+
+#endif


### PR DESCRIPTION
As per https://github.com/rizinorg/sdb/pull/7#discussion_r550905452, this pr checks for an available `getpid()` using Meson and #defines `os_getpid()` accordingly.