### PR TITLE
sdb_ns_unset: Free the given namespace

### DIFF
--- a/src/ns.c
+++ b/src/ns.c
@@ -126,22 +126,24 @@ static SdbNs *sdb_ns_new (Sdb *s, const char *name, ut32 hash) {
 	return ns;
 }
 
+static void sdb_ns_free(SdbNs *ns) {
+	sdb_free (ns->sdb);
+	free (ns->name);
+	free (ns);
+}
+
 SDB_API bool sdb_ns_unset (Sdb *s, const char *name, Sdb *r) {
 	SdbNs *ns;
 	SdbListIter *it;
 	if (s && (name || r)) {
 		ls_foreach (s->ns, it, ns) {
 			if (name && (!strcmp (name, ns->name))) {
-				sdb_free (ns->sdb);
-				free (ns->name);
-				free (ns);
+				sdb_ns_free (ns);
 				ls_delete (s->ns, it);
 				return true;
 			}
 			if (r && ns->sdb == r) {
-				sdb_free (ns->sdb);
-				free (ns->name);
-				free (ns);
+				sdb_ns_free (ns);
 				ls_delete (s->ns, it);
 				return true;
 			}

--- a/src/ns.c
+++ b/src/ns.c
@@ -132,10 +132,16 @@ SDB_API bool sdb_ns_unset (Sdb *s, const char *name, Sdb *r) {
 	if (s && (name || r)) {
 		ls_foreach (s->ns, it, ns) {
 			if (name && (!strcmp (name, ns->name))) {
+				sdb_free (ns->sdb);
+				free (ns->name);
+				free (ns);
 				ls_delete (s->ns, it);
 				return true;
 			}
 			if (r && ns->sdb == r) {
+				sdb_free (ns->sdb);
+				free (ns->name);
+				free (ns);
 				ls_delete (s->ns, it);
 				return true;
 			}

--- a/src/ns.c
+++ b/src/ns.c
@@ -25,7 +25,7 @@ static int in_list(SdbList *list, void *item) {
 	return 0;
 }
 
-static void ns_free(Sdb *s, SdbList *list) {
+static void ns_free_exc_list(Sdb *s, SdbList *list) {
 	SdbListIter next;
 	SdbListIter *it;
 	int deleted;
@@ -55,7 +55,7 @@ static void ns_free(Sdb *s, SdbList *list) {
 			}
 			ls_append (list, ns);
 			ls_append (list, ns->sdb);
-			ns_free (ns->sdb, list);
+			ns_free_exc_list (ns->sdb, list);
 			sdb_free (ns->sdb);
 		}
 		if (!deleted) {
@@ -70,14 +70,14 @@ static void ns_free(Sdb *s, SdbList *list) {
 	s->ns = NULL;
 }
 
-SDB_API void sdb_ns_free(Sdb *s) {
+SDB_API void sdb_ns_free_all(Sdb *s) {
 	SdbList *list;
 	if (!s) {
 		return;
 	}
 	list = ls_new ();
 	list->free = NULL;
-	ns_free (s, list);
+	ns_free_exc_list (s, list);
 	ls_free (list);
 	ls_free (s->ns);
 	s->ns = NULL;

--- a/src/sdb.c
+++ b/src/sdb.c
@@ -193,7 +193,7 @@ static void sdb_fini(Sdb* s, int donull) {
 	if (s->lock) {
 		sdb_unlock (sdb_lock_file (s->dir));
 	}
-	sdb_ns_free (s);
+	sdb_ns_free_all (s);
 	s->refs = 0;
 	free (s->name);
 	free (s->path);

--- a/src/sdb.h
+++ b/src/sdb.h
@@ -281,7 +281,7 @@ SDB_API const char *sdb_json_format(SdbJsonString* s, const char *fmt, ...);
 SDB_API Sdb* sdb_ns(Sdb *s, const char *name, int create);
 SDB_API Sdb *sdb_ns_path(Sdb *s, const char *path, int create);
 SDB_API void sdb_ns_init(Sdb* s);
-SDB_API void sdb_ns_free(Sdb* s);
+SDB_API void sdb_ns_free_all(Sdb* s);
 SDB_API void sdb_ns_lock(Sdb *s, int lock, int depth);
 SDB_API void sdb_ns_sync(Sdb* s);
 SDB_API int sdb_ns_set(Sdb *s, const char *name, Sdb *r);


### PR DESCRIPTION
This pr makes `sdb_ns_unset` free the namespace given to it. This fixes Rizin's `asm.arch`/`bits`/`os` syscall memleak problems.