### PR TITLE
Just use python used to run meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('sdb', 'c', meson_version: '>=0.50.0', default_options: [
   'buildtype=debugoptimized', 'b_vscrt=from_buildtype'
 ])
-py3_exe = import('python').find_installation('python3')
+py3_exe = import('python').find_installation()
 pkgconfig_mod = import('pkgconfig')
 cc = meson.get_compiler('c')
 


### PR DESCRIPTION
I remember you told me about an issue in gentoo. This should likely solve the problem, because it is the same thing done in rizin itself. By not providing an argument, `find_installation` will just return the python version used to run meson itself, so we should be good.