### PR TITLE
Add ht_*_delete_ref() that does not free

### DIFF
--- a/src/ht_inc.c
+++ b/src/ht_inc.c
@@ -350,6 +350,26 @@ SDB_API bool Ht_(delete)(HtName_(Ht)* ht, const KEY_TYPE key) {
 	return false;
 }
 
+// Deletes a entry from the hash table from the key, if the pair exists,
+// without triggering the corresponding free() function
+SDB_API bool Ht_(delete_ref)(HtName_(Ht)* ht, const KEY_TYPE key) {
+	HT_(Bucket) *bt = &ht->table[bucketfn (ht, key)];
+	ut32 key_len = calcsize_key (ht, key);
+	HT_(Kv) *kv;
+	ut32 j;
+
+	BUCKET_FOREACH (ht, bt, j, kv) {
+		if (is_kv_equal (ht, key, key_len, kv)) {
+			void *src = next_kv (ht, kv);
+			memmove (kv, src, (bt->count - j - 1) * ht->opt.elem_size);
+			bt->count--;
+			ht->count--;
+			return true;
+		}
+	}
+	return false;
+}
+
 SDB_API void Ht_(foreach)(HtName_(Ht) *ht, HT_(ForeachCallback) cb, void *user) {
 	ut32 i;
 

--- a/src/ht_inc.h
+++ b/src/ht_inc.h
@@ -104,6 +104,8 @@ SDB_API bool Ht_(update)(HtName_(Ht)* ht, const KEY_TYPE key, VALUE_TYPE value);
 SDB_API bool Ht_(update_key)(HtName_(Ht)* ht, const KEY_TYPE old_key, const KEY_TYPE new_key);
 // Delete a key from the hashtable.
 SDB_API bool Ht_(delete)(HtName_(Ht)* ht, const KEY_TYPE key);
+// Delete a key from the hashtable without freeing the value.
+SDB_API bool Ht_(delete_ref)(HtName_(Ht)* ht, const KEY_TYPE key);
 // Find the value corresponding to the matching key.
 SDB_API VALUE_TYPE Ht_(find)(HtName_(Ht)* ht, const KEY_TYPE key, bool* found);
 // Iterates over all elements in the hashtable, calling the cb function on each Kv.


### PR DESCRIPTION
To allow removing the elements from the hashtable without triggering the free function, unlike `ht_*_delete()`.