### PR TITLE
Fix null pointer dereference

### DIFF
--- a/src/ht_inc.c
+++ b/src/ht_inc.c
@@ -302,7 +302,6 @@ SDB_API HT_(Kv)* Ht_(find_kv)(HtName_(Ht)* ht, const KEY_TYPE key, bool* found) 
 		*found = false;
 	}
 	if (!ht) {
-		*found = false;
 		return NULL;
 	}
 


### PR DESCRIPTION
- CID 316194: Dereference after null check (FORWARD_NULL)
- CID 316253: Dereference after null check (FORWARD_NULL)
- CID 316007: Dereference after null check (FORWARD_NULL)
- CID 316277: Dereference after null check (FORWARD_NULL)