### PR TITLE
Check against Mac OS X 10.6 instead of ppc for posix_memalign

### DIFF
--- a/src/cdb_make.c
+++ b/src/cdb_make.c
@@ -6,10 +6,15 @@
 #include "cdb.h"
 #include "cdb_make.h"
 
+#if __APPLE__
+// for MAC_OS_X_VERSION_10_6
+#include <AvailabilityMacros.h>
+#endif
+
 #define ALIGNMENT sizeof (void*)
 
 char *cdb_alloc(ut32 n) {
-#if __APPLE__ && !__POWERPC__
+#if __APPLE__ && defined(MAC_OS_X_VERSION_10_6)
 	void *ret = NULL;
 	return posix_memalign (&ret, ALIGNMENT, n)? NULL: ret;
 #elif __SDB_WINDOWS__ && !__CYGWIN__


### PR DESCRIPTION
10.6 removed ppc support, so the `__POWERPC__` check is not necessary anymore.

Tested on:
- [x] 10.5/ppc
- [x] 10.5/x86 (previously broken)
- [x] 10.6/x86
- [x] 11.6/arm64