### PR TITLE
Add extern "C" to individual headers for C++

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -3,6 +3,10 @@
 
 #include "types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef int (*BufferOp)(int, const char *, int);
 
 typedef struct buffer {
@@ -53,5 +57,9 @@ extern buffer *buffer_0small;
 extern buffer *buffer_1;
 extern buffer *buffer_1small;
 extern buffer *buffer_2;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/cdb.h
+++ b/src/cdb.h
@@ -6,6 +6,10 @@
 #include <string.h>
 #include "types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define KVLSZ 4
 #define CDB_MAX_KEY 0xff
 #define CDB_MAX_VALUE 0xffffff
@@ -35,5 +39,9 @@ int cdb_findnext(struct cdb *, ut32 u, const char *, ut32);
 
 #define cdb_datapos(c) ((c)->dpos)
 #define cdb_datalen(c) ((c)->dlen)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/cdb_make.h
+++ b/src/cdb_make.h
@@ -6,6 +6,10 @@
 #include "buffer.h"
 #include "types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CDB_HPLIST 1000
 
 struct cdb_hp { ut32 h; ut32 p; } ;
@@ -36,5 +40,9 @@ extern int cdb_make_addbegin(struct cdb_make *,unsigned int,unsigned int);
 extern int cdb_make_addend(struct cdb_make *,unsigned int,unsigned int,ut32);
 extern int cdb_make_add(struct cdb_make *,const char *,unsigned int,const char *,unsigned int);
 extern int cdb_make_finish(struct cdb_make *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ht_pp.h
+++ b/src/ht_pp.h
@@ -1,6 +1,10 @@
 #ifndef SDB_HT_PP_H
 #define SDB_HT_PP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This header provides an hashtable HtPP that has void* as key and void* as
  * value. The API functions starts with "ht_pp_" and the types starts with "HtPP".
@@ -12,5 +16,9 @@ SDB_API HtName_(Ht)* Ht_(new0)(void);
 SDB_API HtName_(Ht)* Ht_(new)(HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) valueSize);
 SDB_API HtName_(Ht)* Ht_(new_size)(ut32 initial_size, HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) valueSize);
 #undef HT_TYPE
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ht_pu.h
+++ b/src/ht_pu.h
@@ -1,6 +1,10 @@
 #ifndef SDB_HT_PU_H
 #define SDB_HT_PU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This header provides an hashtable HtPU that has void* as key and ut64 as
  * value. The API functions starts with "ht_pu_" and the types starts with "HtPU".
@@ -10,5 +14,9 @@
 
 SDB_API HtName_(Ht)* Ht_(new0)(void);
 #undef HT_TYPE
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ht_up.h
+++ b/src/ht_up.h
@@ -1,6 +1,10 @@
 #ifndef SDB_HT_UP_H
 #define SDB_HT_UP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This header provides an hashtable HtUP that has ut64 as key and void* as
  * value. The API functions starts with "ht_up_" and the types starts with "HtUP".
@@ -12,5 +16,9 @@ SDB_API HtName_(Ht)* Ht_(new0)(void);
 SDB_API HtName_(Ht)* Ht_(new)(HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) valueSize);
 SDB_API HtName_(Ht)* Ht_(new_size)(ut32 initial_size, HT_(DupValue) valdup, HT_(KvFreeFunc) pair_free, HT_(CalcSizeV) valueSize);
 #undef HT_TYPE
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ht_uu.h
+++ b/src/ht_uu.h
@@ -1,6 +1,10 @@
 #ifndef SDB_HT_H_
 #define SDB_HT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This header provides an hashtable Ht that has ut64 as key and ut64 as
  * value. The API functions starts with "ht_" and the types starts with "Ht".
@@ -10,5 +14,9 @@
 
 SDB_API HtName_(Ht)* Ht_(new0)(void);
 #undef HT_TYPE
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/ls.h
+++ b/src/ls.h
@@ -4,6 +4,10 @@
 #include <stdio.h>
 #include "types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void (*SdbListFree)(void *ptr);
 typedef int (*SdbListComparator)(const void *a, const void *b);
 
@@ -71,5 +75,9 @@ SDB_API int ls_join(SdbList *first, SdbList *second);
 SDB_API int ls_del_n(SdbList *list, int n);
 SDB_API SdbListIter *ls_insert(SdbList *list, int n, void *data);
 SDB_API void *ls_pop_head(SdbList *list);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/sdbht.h
+++ b/src/sdbht.h
@@ -3,6 +3,10 @@
 
 #include "ht_pp.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** keyvalue pair **/
 typedef struct sdb_kv {
 	//sub of HtPPKv so we can cast safely
@@ -48,5 +52,9 @@ SDB_API bool sdb_ht_delete(HtPP* ht, const char* key);
 SDB_API char* sdb_ht_find(HtPP* ht, const char* key, bool* found);
 // Find the KeyValuePair corresponding to the matching key.
 SDB_API SdbKv* sdb_ht_find_kvp(HtPP* ht, const char* key, bool* found);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __SDB_HT_H

--- a/src/set.h
+++ b/src/set.h
@@ -4,6 +4,10 @@
 #include "ht_pp.h"
 #include "ht_up.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef HtPP SetP;
 
 SDB_API SetP *set_p_new(void);
@@ -19,5 +23,9 @@ SDB_API void set_u_add(SetU *p, ut64 u);
 SDB_API bool set_u_contains(SetU *s, ut64 u);
 SDB_API void set_u_delete(SetU *s, ut64 u);
 SDB_API void set_u_free(SetU *p);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -9,6 +9,10 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef HAVE_EPRINTF
 #undef eprintf
 #define eprintf(...) fprintf(stderr,__VA_ARGS__)
@@ -144,5 +148,9 @@ static inline void ut32_unpack(char s[4], ut32 *u) {
 	result += (ut8) s[0];
 	*u = result;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Cutter is broken because `ht_pp.h` was included recently directly in `rz_core.h`.